### PR TITLE
Add translation to lookupform.phtml

### DIFF
--- a/view/frontend/templates/customer/lookupform.phtml
+++ b/view/frontend/templates/customer/lookupform.phtml
@@ -14,7 +14,7 @@
         <legend class="legend"><span><?= $block->escapeHtml(__('Guest Order Information')) ?></span></legend><br>
         <div class="field field-order-increment required">
             <label class="label" for="order-increment">
-                <span>Order Number</span>
+                <span><?= __('Order Number') ?></span>
             </label>
 
             <div class="control">
@@ -23,7 +23,7 @@
         </div>
         <div class="field field-email required">
             <label class="label" for="email">
-                <span>Email</span>
+                <span><?= __('Email') ?></span>
             </label>
 
             <div class="control">


### PR DESCRIPTION
2 Labels in the lookupform.phtml aren't translated. This hotfix adds translation to those fields.